### PR TITLE
Statement Resolution

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ where
 /// Nodes used as base indentifiers or to refer to other graphs.
 ///
 /// Examples of nodes: `A`, `a`, `G1`...
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Node<'src>(&'src str);
 
 impl<'src> Parse<'src> for Node<'src> {
@@ -40,7 +40,7 @@ impl<'src> std::fmt::Display for Node<'src> {
 /// { A, B }
 /// { A, [B, C] }
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Expr<'src> {
     Node(Node<'src>),
     Connected(Vec<Expr<'src>>),
@@ -70,6 +70,17 @@ impl<'src> Parse<'src> for Expr<'src> {
 
             choice((node, connected, disconnected)).padded()
         })
+    }
+}
+
+impl<'src> Expr<'src> {
+    pub fn contains_node(&self, node: &Node<'src>) -> bool {
+        match self {
+            Expr::Node(n) => node == n,
+            Expr::Connected(exprs) | Expr::Disconnected(exprs) => {
+                exprs.iter().all(|e| e.contains_node(node))
+            }
+        }
     }
 }
 
@@ -159,6 +170,9 @@ impl<'src> std::fmt::Display for Ret<'src> {
 
 mod normal;
 pub use self::normal::Normalize;
+
+pub mod resolve;
+pub use self::resolve::Resolve;
 
 #[cfg(test)]
 mod tests {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,38 +1,26 @@
-use grapl::{Expr, Normalize, Parse};
+use chumsky::Parser;
+use grapl::resolve::{Config, Env};
+use grapl::{Expr, Normalize, Parse, Resolve, Stmt};
 use microxdg::{Xdg, XdgError};
-use rustyline::DefaultEditor;
 use rustyline::error::ReadlineError;
+use rustyline::history::FileHistory;
+use rustyline::{DefaultEditor, Editor};
 use std::fs;
 use std::path::PathBuf;
 
-const HISTFILE: &'static str = "grapl.history";
-
 fn main() -> rustyline::Result<()> {
     let mut rl = DefaultEditor::new()?;
+    load_history(&mut rl);
 
-    if let Ok(mut state) = get_xdg_state_dir() {
-        state.push("grapl");
-        if fs::create_dir_all(&state).is_ok() {
-            state.push(HISTFILE);
-            rl.load_history(&state).ok();
-        }
-    }
+    let config = Config::default().with_shadowing();
+    let mut env = Env::new(&config);
 
     loop {
         let readline = rl.readline("> ");
         match readline {
-            Ok(line) => match Expr::parse(line.as_str()).into_result() {
-                Ok(expr) => {
-                    rl.add_history_entry(line.as_str()).unwrap();
-                    println!("{}", expr.normalize());
-                }
-                Err(errors) => {
-                    println!("Invalid syntax:");
-                    for error in errors {
-                        println!("{}", error)
-                    }
-                }
-            },
+            Ok(line) => {
+                handle_line(line, &mut env, &mut rl);
+            }
             Err(ReadlineError::Interrupted) => {
                 println!("Ctrl-C pressed. Exiting.");
                 break;
@@ -48,16 +36,74 @@ fn main() -> rustyline::Result<()> {
         }
     }
 
-    // TODO: Refactor to remove duplicate code in loading.
-    if let Ok(mut state) = get_xdg_state_dir() {
-        state.push("grapl");
-        if fs::create_dir_all(&state).is_ok() {
-            state.push(HISTFILE);
-            rl.save_history(&state).ok();
-        }
-    }
+    save_history(&mut rl);
 
     Ok(())
+}
+
+// TODO: This should be in lib in some way.
+enum Fixme {
+    Expr(Expr),
+    Stmt(Stmt),
+}
+
+fn repl_parser<'src>() -> impl Parser<'src, &'src str, Fixme> {
+    let stmt = Stmt::parser().map(|s| Fixme::Stmt(s));
+    let expr = Expr::parser().map(|e| Fixme::Expr(e));
+    stmt.or(expr)
+}
+
+fn handle_line<'cfg, 'src>(line: String, env: &mut Env<'cfg>, rl: &mut Editor<(), FileHistory>) {
+    match repl_parser().parse(&line).into_result() {
+        Ok(fixme) => {
+            rl.add_history_entry(&line).unwrap();
+            match fixme {
+                Fixme::Expr(expr) => match expr.resolve(env) {
+                    Ok(expr) => println!("{}", expr.normalize()),
+                    Err(err) => println!("Error: {:?}", err),
+                },
+                Fixme::Stmt(stmts) => {
+                    if let Err(err) = stmts.resolve(env) {
+                        println!("Error: {:?}", err);
+                    }
+                }
+            }
+        }
+        Err(_errors) => {
+            println!("Error: Invalid syntax");
+            // for error in errors {
+            //     println!("{}", error)
+            // }
+        }
+    }
+}
+
+const HISTDIR: &'static str = "grapl";
+const HISTFILE: &'static str = "grapl.history";
+
+fn load_history(rl: &mut Editor<(), FileHistory>) {
+    with_histfile(rl, |rl, path| {
+        rl.load_history(path).ok();
+    });
+}
+
+fn save_history(rl: &mut Editor<(), FileHistory>) {
+    with_histfile(rl, |rl, path| {
+        rl.save_history(path).ok();
+    });
+}
+
+fn with_histfile<F>(rl: &mut Editor<(), FileHistory>, func: F)
+where
+    F: Fn(&mut Editor<(), FileHistory>, &PathBuf),
+{
+    if let Ok(mut path) = get_xdg_state_dir() {
+        path.push(HISTDIR);
+        if fs::create_dir_all(&path).is_ok() {
+            path.push(HISTFILE);
+            func(rl, &path)
+        }
+    }
 }
 
 fn get_xdg_state_dir() -> Result<PathBuf, XdgError> {

--- a/src/normal.rs
+++ b/src/normal.rs
@@ -15,7 +15,7 @@ pub trait Normalize {
     fn normalize(&self) -> Self;
 }
 
-impl<'src> Normalize for Expr<'src> {
+impl<'src> Normalize for Expr {
     fn normalize(&self) -> Self {
         match self {
             Expr::Node(node) => Expr::Node(node.clone()),
@@ -131,7 +131,7 @@ impl<'src> Normalize for Expr<'src> {
     }
 }
 
-impl<'src> Normalize for Stmt<'src> {
+impl<'src> Normalize for Stmt {
     fn normalize(&self) -> Self {
         match self {
             Stmt::Assign(node, expr) => Stmt::Assign(node.clone(), expr.normalize()),
@@ -139,7 +139,7 @@ impl<'src> Normalize for Stmt<'src> {
     }
 }
 
-impl<'src> Normalize for Ret<'src> {
+impl<'src> Normalize for Ret {
     fn normalize(&self) -> Self {
         let norm_stmts = self.0.iter().map(Normalize::normalize).collect();
         let norm_expr = self.1.normalize();

--- a/src/normal.rs
+++ b/src/normal.rs
@@ -313,54 +313,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
-    fn normalize_referent_stmt() {
-        assert_eq!(
-            Vec::<Stmt>::parser()
-                .parse(
-                    r#"
-                    G1 = [A, B]
-                    G2 = {X, G1}
-                    "#
-                )
-                .unwrap()
-                .iter()
-                .map(Normalize::normalize)
-                .collect::<Vec<_>>(),
-            Vec::<Stmt>::parser()
-                .parse(
-                    r#"
-                    G1 = [A, B]
-                    G2 = [{X, A}, {X, B}]
-                "#
-                )
-                .unwrap(),
-        );
-        // TODO: Consider this case a little more.
-        assert_eq!(
-            Vec::<Stmt>::parser()
-                .parse(
-                    r#"
-                    G1 = G2
-                    G2 = G1
-                    "#
-                )
-                .unwrap()
-                .iter()
-                .map(Normalize::normalize)
-                .collect::<Vec<_>>(),
-            Vec::<Stmt>::parser()
-                .parse(
-                    r#"
-                    G1 = G2
-                    G2 = G2
-                "#
-                )
-                .unwrap(),
-        );
-    }
-
-    #[test]
     fn normalize_ret() {
         assert_eq!(
             Ret::parser()

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,0 +1,335 @@
+use crate::{Expr, Node, Ret, Stmt};
+use std::collections::HashMap;
+
+/// Graph resolution configuration options.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Config {
+    shadowing: bool,
+    // TODO: This will probably start by looking something like this:
+    // ```
+    // Config { recursion: Recursion, ... }
+    // struct RecursionConfig { limit: usize, ... }
+    // struct Recursion { config: &RecursionConfig, depth: usize, ... }
+    // struct Env(HashMap, Config, Recursion)
+    // ```
+    recursion: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            // TODO: Is the right default?
+            shadowing: false,
+            recursion: false,
+        }
+    }
+}
+
+impl Config {
+    pub fn with_shadowing(mut self) -> Self {
+        self.shadowing = true;
+        self
+    }
+
+    pub fn with_recursion(mut self) -> Self {
+        self.recursion = true;
+        self
+    }
+}
+
+#[derive(Debug)]
+/// Errors that can occur during resolution.
+pub enum Error {
+    /// ```grapl
+    /// G = {A, B}
+    /// G = {B, C}
+    /// ```
+    Shadowing,
+    /// ```grapl
+    /// G = {G, B}
+    /// ```
+    Recursion,
+}
+
+/// Running resolution environment used to maintain state.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Env<'cfg, 'src>(HashMap<Node<'src>, Expr<'src>>, &'cfg Config);
+
+impl<'cfg, 'src> Env<'cfg, 'src> {
+    pub fn new(config: &'cfg Config) -> Self {
+        Env(HashMap::new(), config)
+    }
+
+    pub fn lookup(&self, node: &Node<'src>) -> Expr<'src> {
+        if let Some(expr) = self.0.get(node) {
+            expr.clone()
+        } else {
+            Expr::Node(node.clone())
+        }
+    }
+
+    pub fn insert(&mut self, node: Node<'src>, expr: Expr<'src>) -> Result<(), Error> {
+        if !self.1.shadowing && self.0.contains_key(&node) {
+            Err(Error::Shadowing)
+        } else if !self.1.recursion && expr.contains_node(&node) {
+            Err(Error::Recursion)
+        } else {
+            self.0.insert(node, expr);
+            Ok(())
+        }
+    }
+}
+
+/// Resolution of named graphs in [`Ret`] and slices of [`Stmt`] structures.
+///
+/// ```grapl
+/// G = [A, B]
+/// {X, G}
+/// =>
+/// [{X, A}, {X, B}]
+/// ```
+pub trait Resolve<'src>
+where
+    Self: Sized,
+{
+    fn resolve<'cfg>(&self, env: &mut Env<'cfg, 'src>) -> Result<Self, Error>;
+}
+
+impl<'src> Resolve<'src> for Expr<'src> {
+    fn resolve<'cfg>(&self, env: &mut Env<'cfg, 'src>) -> Result<Self, Error> {
+        macro_rules! inner {
+            ($exprs:expr, $variant:path) => {{
+                let mut fresh = vec![];
+                for expr in $exprs {
+                    fresh.push(expr.resolve(env)?);
+                }
+                Ok($variant(fresh))
+            }};
+        }
+
+        match self {
+            Expr::Node(node) => Ok(env.lookup(node)),
+            Expr::Connected(exprs) => inner!(exprs, Expr::Connected),
+            Expr::Disconnected(exprs) => inner!(exprs, Expr::Disconnected),
+        }
+    }
+}
+
+impl<'src> Resolve<'src> for Vec<Stmt<'src>> {
+    fn resolve<'cfg>(&self, env: &mut Env<'cfg, 'src>) -> Result<Self, Error> {
+        let mut fresh = vec![];
+        for stmt in self {
+            match stmt {
+                Stmt::Assign(node, expr) => {
+                    let resolved = expr.resolve(env)?;
+                    env.insert(node.clone(), resolved.clone())?;
+                    fresh.push(Stmt::Assign(node.clone(), resolved));
+                }
+            }
+        }
+        Ok(fresh)
+    }
+}
+
+impl<'src> Resolve<'src> for Ret<'src> {
+    fn resolve<'cfg>(&self, env: &mut Env<'cfg, 'src>) -> Result<Self, Error> {
+        let stmts = self.0.resolve(env);
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        Expr, Node, Parse, Resolve, Stmt,
+        resolve::{Config, Env},
+    };
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn resolve_expr() {
+        let config = Config::default();
+        let mut env = Env::new(&config);
+        env.insert(Node("A"), Expr::Node(Node("B"))).unwrap();
+
+        assert_eq!(
+            Expr::parse("A").unwrap().resolve(&mut env).unwrap(),
+            Expr::parse("B").unwrap(),
+        );
+    }
+
+    #[test]
+    fn resolve_stmts() {
+        let config = Config::default();
+        let mut env = Env::new(&config);
+
+        assert_eq!(
+            Vec::<Stmt>::parse(
+                r#"
+                    G1 = [A, B]
+                    G2 = {X, G1}
+                "#
+            )
+            .unwrap()
+            .resolve(&mut env)
+            .unwrap(),
+            Vec::<Stmt>::parse(
+                r#"
+                    G1 = [A, B]
+                    G2 = {X, [A, B]}
+                "#
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn resolve_shadowing() {
+        let config = Config::default().with_shadowing();
+        let mut env = Env::new(&config);
+
+        assert_eq!(
+            Vec::<Stmt>::parse(
+                r#"
+                    G1 = A
+                    G1 = B
+                    G2 = G1
+                "#
+            )
+            .unwrap()
+            .resolve(&mut env)
+            .unwrap(),
+            Vec::<Stmt>::parse(
+                r#"
+                    G1 = A
+                    G1 = B
+                    G2 = B
+                "#
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn resolve_apparent_recursion_shadowing() {
+        let config = Config::default().with_shadowing();
+        let mut env = Env::new(&config);
+
+        assert_eq!(
+            Vec::<Stmt>::parse(
+                r#"
+                    G1 = G2
+                    G2 = G1
+                "#
+            )
+            .unwrap()
+            .resolve(&mut env)
+            .unwrap(),
+            Vec::<Stmt>::parse(
+                r#"
+                    G1 = G2
+                    G2 = G2
+                "#
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn resolve_recursion() {
+        let config = Config::default().with_recursion();
+        let mut env = Env::new(&config);
+
+        assert_eq!(
+            Vec::<Stmt>::parse(
+                r#"
+                    G = {G, X}
+                "#
+            )
+            .unwrap()
+            .resolve(&mut env)
+            .unwrap(),
+            // TODO: Handle multi-step resolution and proper recursion end
+            // conditions.
+            Vec::<Stmt>::parse(
+                r#"
+                    G = {{G..., X}, X}
+                "#
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn resolve_mutual_recursion() {
+        let config = Config::default().with_recursion();
+        let mut env = Env::new(&config);
+
+        assert_eq!(
+            Vec::<Stmt>::parse(
+                r#"
+                    G1 = {G2, X}
+                    G2 = {G1, Y}
+                "#
+            )
+            .unwrap()
+            .resolve(&mut env)
+            .unwrap(),
+            Vec::<Stmt>::parse(
+                r#"
+                    G1 = {{G1..., Y}, X}
+                    G2 = {{G2..., X}, Y}
+                "#
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn resolve_direct_mutual_recursion() {
+        let config = Config::default().with_recursion();
+        let mut env = Env::new(&config);
+
+        assert!(
+            Vec::<Stmt>::parse(
+                r#"
+                    G1 = G2
+                    G2 = G1
+                "#
+            )
+            .unwrap()
+            .resolve(&mut env)
+            .is_err()
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn resolve_direct_mutual_recursion_shadowing() {
+        let config = Config::default().with_recursion().with_shadowing();
+        let mut env = Env::new(&config);
+
+        // This is going to eventually be an error in one way or another.
+        assert_eq!(
+            Vec::<Stmt>::parse(
+                r#"
+                    G1 = G2
+                    G2 = G1
+                "#
+            )
+            .unwrap()
+            .resolve(&mut env)
+            .unwrap(),
+            Vec::<Stmt>::parse(
+                r#"
+                    G1 = G2...
+                    G2 = G1...
+                "#
+            )
+            .unwrap(),
+        );
+    }
+}

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -8,6 +8,7 @@
 
 use crate::{Expr, Node, Ret, Stmt};
 use std::collections::HashMap;
+use std::fmt;
 
 /// Graph resolution configuration options.
 #[derive(Debug, PartialEq, Eq)]
@@ -100,6 +101,16 @@ impl<'cfg> Env<'cfg> {
             self.0.insert(node, expr);
             Ok(())
         }
+    }
+}
+
+/// Implement Display for Env to show its contents.
+impl<'cfg> fmt::Display for Env<'cfg> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (node, expr) in &self.0 {
+            writeln!(f, "{} = {}", node, expr)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -288,7 +288,7 @@ mod tests {
         assert_eq!(
             Vec::<Stmt>::parse(
                 r#"
-                    G1 = G2
+                    G1 = A
                     G2 = G1
                 "#
             )
@@ -297,8 +297,8 @@ mod tests {
             .unwrap(),
             Vec::<Stmt>::parse(
                 r#"
-                    G1 = G2
-                    G2 = G2
+                    G1 = A
+                    G2 = A
                 "#
             )
             .unwrap(),


### PR DESCRIPTION
In short, this allows `G = A G => A`. More generally, it enables graphs with `Stmt::Assign` statements to replace the future references to the bound node with its expression. There are a few options to the algorithm that can be set with `resolve::Config`. Binding state is saved in `resolve::Env`.

### Configuration

##### Shadowing

The configuration option `Config.shadowing` allows for `A = B A = C A => C`.

##### Recursion

This is tricky and currently unimplemented.

---

- [x] `Expr.resolve`
- [x] `Vec<Stmt>.resolve`
- [x] `Ret.resolve`
- [x] Update REPL